### PR TITLE
get git version from searxng/searxng

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,12 @@ apk -U upgrade \
 && apk add --no-cache ca-certificates git su-exec python3 py3-pip libxml2 libxslt openssl tini uwsgi uwsgi-python3 brotli \
 && git clone https://github.com/searxng/searxng.git . \
 && chown -R searx:searx . \
-&& git remote set-url origin https://github.com/paulgoio/searx.git \
 && pip install --upgrade pip \
 && pip install --no-cache -r requirements.txt \
 && apk del build-dependencies \
-&& rm -rf /var/cache/apk/* /root/.cache
+&& rm -rf /var/cache/apk/* /root/.cache \
+&& su searx -c "/usr/bin/python3 -m searx.version freeze" \
+&& sed -i -e "/GIT_URL/s/searxng\/searxng/paulgoio\/searx/" searx/version_frozen.py
 
 # copy custom simple themes and run.sh
 COPY --from=builder /css/* searx/static/themes/simple/css/


### PR DESCRIPTION
[EDIT] This PR is more a documentation how to get the git version from searxng than code to merge.

The version from the searxng repository:

![image](https://user-images.githubusercontent.com/1594191/129390729-8fe0de01-3a0b-4506-a86d-d5805f7dc2c8.png)

"source code" is a link to https://github.com/paulgoio/searx

---

```
git remote set-url origin https://github.com/paulgoio/searx.git \
&& git fetch origin \
&& git branch --set-upstream-to=origin/main \ 
&& su searx -c "/usr/bin/python3 -m searx.version freeze" \
```
will do produce the same result than this PR:
* VERSION_STRING from searxng (result of [`git describe HEAD`](https://github.com/searxng/searxng/blob/9667142d5c45ae52f19b361e69a61900e09fe005/searx/version.py#L63))
* GIT_URL="https://github.com/paulgoio/searx"

---

The alternative is to get the git version from this repository, but without a git tag the version looks like "2021-08-13-fd42156" (result of [`git show -s --format='%as-%h'`](https://github.com/searxng/searxng/blob/9667142d5c45ae52f19b361e69a61900e09fe005/searx/version.py#L78))

---

* `python3 -m searx.version freeze` creates `searx/version_frozen.py` : once created, the version is read from this file. See: https://github.com/searxng/searxng/blob/9667142d5c45ae52f19b361e69a61900e09fe005/manage#L256
* `python3 -m searx.version` displays `VERSION_STRING`, `VERSION_TAG`, `GIT_URL`, `GIT_BRANCH`.
* `eval "$(python3 -m searx.version)"` will set these variables in the current shell.
